### PR TITLE
Allow input_file to be a URL

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -48,6 +48,13 @@ get_content <- function(input_file, format, api_key) {
 convert_pdf <- function(input_file, output_file = NULL, format = "csv",
                         message = TRUE, api_key = Sys.getenv("pdftable_api")) {
 
+  if (grepl("^http://|^https://|^ftp://|^file://",input_file)){
+    tmp <- tempfile(fileext = ".pdf")
+    download.file(url = input_file,destfile = tmp)
+    input_file <- tmp
+    on.exit(file.remove(tmp))
+  }
+
   stopifnot(file.exists(input_file))
 
   format <- tolower(format)

--- a/R/main.R
+++ b/R/main.R
@@ -28,7 +28,11 @@ get_content <- function(input_file, format, api_key) {
 
 #' Convert PDF Tables to format more amenable to analysis
 #'
-#' @param input_file The PDF file to be converted
+#' @param input_file The PDF file to be converted. If this is a url
+#' to a PDF rather than a file path then it is downloaded to a
+#' temporary file via \code{download.file} before being sent to pdftables
+#' for conversion. If \code{input_file} is a url then \code{output_file}
+#' must not be \code{NULL}.
 #' @param output_file The desired name for the output file
 #' @param format One of 'csv', 'xlm', 'xlsx-single', 'xlsx-multiple'
 #' @param message If TRUE, outputs a message that conversion was successful
@@ -49,8 +53,12 @@ convert_pdf <- function(input_file, output_file = NULL, format = "csv",
                         message = TRUE, api_key = Sys.getenv("pdftable_api")) {
 
   if (grepl("^http://|^https://|^ftp://|^file://",input_file)){
+    stopifnot(!is.null(output_file))
     tmp <- tempfile(fileext = ".pdf")
-    download.file(url = input_file,destfile = tmp)
+    download_check <- download.file(url = input_file,destfile = tmp)
+    if (download_check != 0){
+      stop("PDF download failed.")
+    }
     input_file <- tmp
     on.exit(file.remove(tmp))
   }

--- a/man/convert_pdf.Rd
+++ b/man/convert_pdf.Rd
@@ -8,7 +8,11 @@ convert_pdf(input_file, output_file = NULL, format = "csv",
   message = TRUE, api_key = Sys.getenv("pdftable_api"))
 }
 \arguments{
-\item{input_file}{The PDF file to be converted}
+\item{input_file}{The PDF file to be converted. If this is a url
+to a PDF rather than a file path then it is downloaded to a
+temporary file via \code{download.file} before being sent to pdftables
+for conversion. If \code{input_file} is a url then \code{output_file}
+must not be \code{NULL}.}
 
 \item{output_file}{The desired name for the output file}
 


### PR DESCRIPTION
Small change that allows input_file to be a URL to a PDF, which is then downloaded (but not saved) before being sent along to be converted.
